### PR TITLE
OSC-string の長さを求める関数を修正

### DIFF
--- a/Runtime/Scripts/OscParser.cs
+++ b/Runtime/Scripts/OscParser.cs
@@ -224,7 +224,7 @@ namespace OscCore
             int index;
             for (index = offset; index < end; index++)
             {
-                if (Buffer[index] != 0) break;
+                if (Buffer[index] == 0) break;
             }
 
             var length = index - offset;


### PR DESCRIPTION
OSC-string の長さを求める関数を修正
* string のバイトデータの先頭から初めて `0x00` が現れる箇所までの長さを求めるはずが、判定式が逆になっていたため `0x00` ではない byte が含まれる箇所までの長さを返していた